### PR TITLE
Add configuration_aliases to terraform required providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,7 @@ terraform {
     aws = {
       source  = "registry.terraform.io/hashicorp/aws"
       version = ">= 4.0"
+      configuration_aliases = [aws.us-east-1]
     }
   }
 }


### PR DESCRIPTION
## What

Add **`configuration_aliases`** to terraform required providers, since this module is used to set WAF up for Cloudfront in **`us-east-1`** AWS Region.
## Why

Resolving Terraform error when using this module; the error states that the aws.us-east-1 provider is not declared in the child module as a required provider.
## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
